### PR TITLE
Corrected "Create your basic config"

### DIFF
--- a/v4/install.md
+++ b/v4/install.md
@@ -32,7 +32,7 @@ parent: v4
 
 4. Create your basic config:
     ```
-    npm init
+    npm run init
     ```
 
 5. Start Poracle:


### PR DESCRIPTION
Changed `npm init` to `npm run init` because `npm init` dosnt create the basic config file