### PR TITLE
Update default username

### DIFF
--- a/v4/database.md
+++ b/v4/database.md
@@ -27,15 +27,15 @@ Just go ahead and create a new DB user and database:
 If Poracle connects to the database locally, you can give it only local access rights:
    ```sql
    CREATE DATABASE poracle;
-   CREATE USER 'poracle'@'localhost' IDENTIFIED BY 'poraclePassword';
-   GRANT ALL PRIVILEGES ON poracle . * TO 'poracle'@'localhost';
+   CREATE USER 'poracleuser'@'localhost' IDENTIFIED BY 'poraclePassword';
+   GRANT ALL PRIVILEGES ON poracle . * TO 'poracleuser'@'localhost';
    exit
    ```
    
 Alternatively, you can grant your user access from anywhere:
    ```sql
    CREATE DATABASE poracle;
-   CREATE USER 'poracle'@'%' IDENTIFIED BY 'poraclePassword';
-   GRANT ALL PRIVILEGES ON poracle . * TO 'poracle'@'%';
+   CREATE USER 'poracleuser'@'%' IDENTIFIED BY 'poraclePassword';
+   GRANT ALL PRIVILEGES ON poracle . * TO 'poracleuser'@'%';
    exit
    ```


### PR DESCRIPTION
The default config, default.json, uses the username `poracleuser`. Updating the username to match the default may help some users.